### PR TITLE
chore: add test-cases for array extraction

### DIFF
--- a/test/scenarios/conditions/data.ts
+++ b/test/scenarios/conditions/data.ts
@@ -39,4 +39,25 @@ export const data: Scenario[] = [
     },
     output: 15,
   },
+  {
+    templatePath: 'undefined-arr-cond.jt',
+    input: {
+      products: [{ a: 1 }, { a: 2 }],
+    },
+    output: 'no',
+  },
+  {
+    templatePath: 'undefined-arr-cond.jt',
+    input: {
+      products: [{ objectID: 1 }, { objectID: 2 }],
+    },
+    output: 'yes',
+  },
+  {
+    templatePath: 'undefined-arr-cond.jt',
+    input: {
+      otherProperty: [{ objectID: 1 }, { objectID: 2 }],
+    },
+    output: 'no',
+  },
 ];

--- a/test/scenarios/conditions/undefined-arr-cond.jt
+++ b/test/scenarios/conditions/undefined-arr-cond.jt
@@ -1,0 +1,2 @@
+let a = ~r .products.objectID;
+Array.isArray(a) ? "yes":"no";


### PR DESCRIPTION
## Description of the change

Added test-cases for array extraction, where in
- The extracted property from a parent array is not present
- The extracted property in parent array is present
- The parent array itself is not defined

This PR serves as an example as well that talks about the usage of `Array.isArray` in json-template-engine

## Checklists

### Development

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request
