### PR TITLE
feat(INT-667): add support for short key value in object expr

### DIFF
--- a/test/scenarios/objects/template.jt
+++ b/test/scenarios/objects/template.jt
@@ -1,14 +1,14 @@
 let c = "c key";
 let d = 3;
+let b = 2;
 let a = {
-    // short form for "a"
-    a: 1,
-    "b": 2,
+    "a": 1,
+    b,
     // [c] coverts to "c key"
     [c]: {
         // this coverts to d: 3
-        d: d
-    }
+        d
+    },
 };
 a.({
     a: .a,


### PR DESCRIPTION
## Description of the change

Add support for following syntax:
```js
let a = 1;
let b = 2;
{
a,
b
}
```
## Checklists

### Development

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request
