### PR TITLE
feat: add support for template strings

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -96,6 +96,7 @@ Give the JSON template engine a try in our [playground](https://transformers-wor
 
 The template consists of multiple statements, with the output being the result of the final statement.
 
+
 ### Variables
 
 ```js
@@ -105,6 +106,15 @@ a + b;
 ```
 
 Refer this [example](test/scenarios/assignments/template.jt) for more details.
+
+#### Template Strings
+
+```js
+let a = `Input a=${.a}`; 
+let b = `Input b=${.b}`;
+`${a}, ${b}`;
+```
+Refer this [example](test/scenarios/template_strings/template.jt) for more details.
 
 ### Basic Expressions
 

--- a/src/lexer.ts
+++ b/src/lexer.ts
@@ -61,6 +61,10 @@ export class JsonTemplateLexer {
     return JsonTemplateLexer.isLiteralToken(this.lookahead());
   }
 
+  matchTemplate(): boolean {
+    return this.matchTokenType(TokenType.TEMPLATE);
+  }
+
   matchINT(steps = 0): boolean {
     return this.matchTokenType(TokenType.INT, steps);
   }
@@ -463,7 +467,7 @@ export class JsonTemplateLexer {
 
     if (eosFound) {
       return {
-        type: TokenType.STR,
+        type: orig === '`' ? TokenType.TEMPLATE : TokenType.STR,
         value: str,
         range: [start, this.idx],
       };

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -990,7 +990,9 @@ export class JsonTemplateParser {
       }
       const end = template.indexOf('}', start);
       if (end === -1) {
-        throw new JsonTemplateParserError('Invalid template expression');
+        throw new JsonTemplateParserError(
+          `Invalid template expression: unclosed expression at ${template}`,
+        );
       }
       if (start > idx) {
         parts.push({
@@ -999,7 +1001,17 @@ export class JsonTemplateParser {
           tokenType: TokenType.STR,
         });
       }
-      parts.push(JsonTemplateEngine.parse(template.slice(start + 2, end), this.options));
+      try {
+        const exprPart = JsonTemplateEngine.parse(
+          template.slice(start + 2, end),
+          this.options,
+        ) as StatementsExpression;
+        parts.push(exprPart.statements[0]);
+      } catch (error: any) {
+        throw new JsonTemplateParserError(
+          `Invalid template expression: ${error.message} at ${template}`,
+        );
+      }
       idx = end + 1;
     }
     return {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -21,6 +21,7 @@ import {
   IncrementExpression,
   IndexFilterExpression,
   Keyword,
+  LambdaArgExpression,
   LiteralExpression,
   LoopControlExpression,
   LoopExpression,
@@ -1427,17 +1428,28 @@ export class JsonTemplateParser {
     return JsonTemplateEngine.parseMappingPaths(flatMappings);
   }
 
-  // eslint-disable-next-line sonarjs/cognitive-complexity
+  private isFloatingNumber(): boolean {
+    return this.lexer.match('.') && this.lexer.matchINT(1) && !this.lexer.match('.', 2);
+  }
+
+  private isLambdaArg(): boolean {
+    return this.lexer.matchTokenType(TokenType.LAMBDA_ARG);
+  }
+
+  private parseLambdaArgExpr(): LambdaArgExpression {
+    return {
+      type: SyntaxType.LAMBDA_ARG,
+      index: this.lexer.value(),
+    };
+  }
+
   private parsePrimaryExpr(): Expression {
     if (this.lexer.match(';')) {
       return EMPTY_EXPR;
     }
 
-    if (this.lexer.matchTokenType(TokenType.LAMBDA_ARG)) {
-      return {
-        type: SyntaxType.LAMBDA_ARG,
-        index: this.lexer.value(),
-      };
+    if (this.isLambdaArg()) {
+      return this.parseLambdaArgExpr();
     }
 
     if (this.lexer.matchKeyword()) {
@@ -1452,7 +1464,7 @@ export class JsonTemplateParser {
       return this.parseArrayCoalesceExpr();
     }
 
-    if (this.lexer.match('.') && this.lexer.matchINT(1) && !this.lexer.match('.', 2)) {
+    if (this.isFloatingNumber()) {
       return this.parseFloatingNumber();
     }
 

--- a/src/reverse_translator.ts
+++ b/src/reverse_translator.ts
@@ -28,6 +28,7 @@ import {
   SpreadExpression,
   StatementsExpression,
   SyntaxType,
+  TemplateExpression,
   ThrowExpression,
   TokenType,
   UnaryExpression,
@@ -69,6 +70,9 @@ export class JsonTemplateReverseTranslator {
         return this.translateBinaryExpression(expr as BinaryExpression);
       case SyntaxType.ARRAY_EXPR:
         return this.translateArrayExpression(expr as ArrayExpression);
+      case SyntaxType.TEMPLATE_EXPR:
+        return this.translateTemplateExpression(expr as TemplateExpression);
+
       case SyntaxType.OBJECT_EXPR:
         return this.translateObjectExpression(expr as ObjectExpression);
       case SyntaxType.SPREAD_EXPR:
@@ -118,6 +122,18 @@ export class JsonTemplateReverseTranslator {
       default:
         return '';
     }
+  }
+
+  translateTemplateExpression(expr: TemplateExpression): string {
+    const code: string[] = [];
+    for (const part of expr.parts) {
+      if (part.type === SyntaxType.LITERAL) {
+        code.push(part.value);
+      } else {
+        code.push(this.translateWithWrapper(part, '${', '}'));
+      }
+    }
+    return `\`${code.join('')}\``;
   }
 
   translateArrayFilterExpression(expr: ArrayFilterExpression): string {

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,6 +28,7 @@ export enum TokenType {
   ID = 'id',
   INT = 'int',
   FLOAT = 'float',
+  TEMPLATE = 'template',
   STR = 'str',
   BOOL = 'bool',
   NULL = 'null',
@@ -95,6 +96,7 @@ export enum SyntaxType {
   STATEMENTS_EXPR = 'statements_expr',
   LOOP_CONTROL_EXPR = 'loop_control_expr',
   LOOP_EXPR = 'loop_expr',
+  TEMPLATE_EXPR = 'TEMPLATE_EXPR',
 }
 
 export enum PathType {
@@ -176,8 +178,8 @@ export interface BinaryExpression extends Expression {
   op: string;
 }
 
-export interface ConcatExpression extends Expression {
-  args: Expression[];
+export interface TemplateExpression extends Expression {
+  parts: Expression[];
 }
 
 export interface AssignmentExpression extends Expression {

--- a/test/scenarios/template_strings/data.ts
+++ b/test/scenarios/template_strings/data.ts
@@ -1,0 +1,17 @@
+import { Scenario } from '../../types';
+
+export const data: Scenario[] = [
+  {
+    input: {
+      a: 'foo',
+    },
+    bindings: {
+      b: 'bar',
+    },
+    output: 'Input a=foo, Binding b=bar',
+  },
+  {
+    template: '`unclosed template ${`',
+    error: 'Invalid template expression',
+  },
+];

--- a/test/scenarios/template_strings/data.ts
+++ b/test/scenarios/template_strings/data.ts
@@ -14,4 +14,8 @@ export const data: Scenario[] = [
     template: '`unclosed template ${`',
     error: 'Invalid template expression',
   },
+  {
+    template: '`invalid template expression ${.a + }`',
+    error: 'Invalid template expression',
+  },
 ];

--- a/test/scenarios/template_strings/template.jt
+++ b/test/scenarios/template_strings/template.jt
@@ -1,0 +1,3 @@
+let a = `Input a=${.a}`; 
+let b = `Binding b=${$.b}`;
+`${a}, ${b}`;


### PR DESCRIPTION
## What are the changes introduced in this PR?
Added support for this syntax:
```js
let a = `Input a=${.a}`; 
let b = `Binding b=${$.b}`;
`${a}, ${b}`;
```

## What is the related Linear task?

Resolves INT-2560

## Please explain the objectives of your changes below

Put down any required details on the broader aspect of your changes. If there are any dependent changes, **mandatorily** mention them here

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### Any technical or performance related pointers to consider with the change?

N/A

@coderabbitai review

<hr>

### Developer checklist

- [ ] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] Is the PR limited to 10 file changes?

- [ ] Is the PR limited to one linear task?

- [ ] Are relevant unit and component test-cases added?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Added support for template strings in the documentation with examples and usage guidance.
	- Introduced functionality for parsing and translating template expressions, enhancing the ability to handle embedded expressions.
	- Expanded token recognition to include template literals, improving parsing logic.
	- Added a new data structure for organized testing of template string scenarios.

- **Bug Fixes**
	- Improved error handling for invalid template syntax during parsing.

- **Documentation**
	- Updated the documentation to include a new section on template strings with examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->